### PR TITLE
Add faGroup field to Orders

### DIFF
--- a/src/ib_re_actor_976_plus/mapping.clj
+++ b/src/ib_re_actor_976_plus/mapping.clj
@@ -245,7 +245,8 @@ create instances, we will only map from objects to clojure maps."
             [:all-or-none? allOrNone]
             [:limit-price lmtPrice]
             [:discretionary-amount discretionaryAmt]
-            [:stop-price auxPrice])
+            [:stop-price auxPrice]
+            [:fa-group faGroup])
 
 (defmapping-readonly com.ib.client.Bar
                      [:time time]


### PR DESCRIPTION
This field is required to allow financial advisor accounts to specify an allocation group for an order.